### PR TITLE
Fix enrich_append args

### DIFF
--- a/oppa-lana-style.zsh-theme
+++ b/oppa-lana-style.zsh-theme
@@ -27,8 +27,8 @@ RPROMPT='%{$reset_color%}%T %{$fg_bold[white]%} %n@%m%{$reset_color%}'
 
 function enrich_append {
     local flag=$1
-    local symbol=$2
-    local color=${3:-$omg_default_color_on}
+    local symbol="$2"
+    local color="${3:-$omg_default_color_on}"
     if [[ $flag == false ]]; then symbol=' '; fi
 
     echo -n "${color}${symbol}  "


### PR DESCRIPTION
(error)[https://leto31e.storage.yandex.net/rdisk/5c24319552b64037ae43764d2b2634d6ef58135b8dcf1c580e8f233b6f1f8fa7/inf/MKHRwh8h6PcOcu-9p0keBVE8iga3n2MzF0ZSsRDizXE6tQbKWrBmOrccV9wWZjZsrnKGUu8FHYnvCAB7Wi8X_g==?uid=0&filename=2015-11-12%2003-15-58%201.%20baymer%4084%3A%20~%20dev%20islands%20%28zsh%29.png&disposition=inline&hash=&limit=0&content_type=image%2Fpng&tknv=v2&rtoken=3f322281923b5fdd8f1c299c3d08d7a0&force_default=no&ycrid=na-210e5bc12bcca6b2e315fe96e310f584-downloader4e]
MacOS: Yosimite
zsh: 5.0.5